### PR TITLE
Add `default()` rule for undefiend properties in scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Any value that isn't an empty string will cause the `type()` rule to fail.
 > [!IMPORTANT]
 > This coercion is only applies for `Ruleset->GET()`. `Ruleset->POST()` will enforce the real `null` value since it's JSON
 
+## `default()`
+```php
+Rules->default(mixed);
+```
+Set superglobal property to a defined default value if the property was not provided in superglobal scope
+
 ## `min()`
 ```php
 Rules->min(?int = null);

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -24,6 +24,9 @@
 		public bool $required = false;
 		public ?Type $type = null;
 
+		private bool $default_enabled = false;
+		public mixed $default;
+
 		public ?int $min = null;
 		public ?int $max = null;
 
@@ -76,6 +79,14 @@
 			return $this;
 		}
 
+		// Set a default value if property is not provided
+		public function default(mixed $value): self {
+			$this->default_enabled = true;
+			$this->default = $value;
+			
+			return $this;
+		}
+
 		/*
 			# Eval methods
 			These methods are used to check conformity against set rules.
@@ -124,8 +135,11 @@
 				return true;
 			}
 
-			// Property does not exist in scope, create nulled superglobal for it
-			$scope_data[$this->property] = null;
+			// Property does not exist in superglobal, create one with default value if enabled
+			if ($this->default_enabled) {
+				$scope_data[$this->property] = $this->default;
+			}
+
 			return false;
 		}
 


### PR DESCRIPTION
This PR adds a new rule that sets a default value on <scope> if the property has not been provided.