### PR TITLE
Evaluate whole `Ruleset`s and set errors from `Error` enum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,5 @@
         "psr-4": {
             "ReflectRules\\": "src/"
         }
-    },
-    "require": {
-        "victorwesterlund/xenum": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,46 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98953f6b9df8b6761e2d57fc66815033",
-    "packages": [
-        {
-            "name": "victorwesterlund/xenum",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/VictorWesterlund/php-xenum.git",
-                "reference": "8972f06f42abd1f382807a67e937d5564bb89699"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/VictorWesterlund/php-xenum/zipball/8972f06f42abd1f382807a67e937d5564bb89699",
-                "reference": "8972f06f42abd1f382807a67e937d5564bb89699",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "victorwesterlund\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Westerlund",
-                    "email": "victor.vesterlund@gmail.com"
-                }
-            ],
-            "description": "PHP eXtended Enums. The missing quality-of-life features from PHP 8+ Enums",
-            "support": {
-                "issues": "https://github.com/VictorWesterlund/php-xenum/issues",
-                "source": "https://github.com/VictorWesterlund/php-xenum/tree/1.1.1"
-            },
-            "time": "2023-11-20T10:10:39+00:00"
-        }
-    ],
+    "content-hash": "7c02351f2b860153c02a8f683d9c540f",
+    "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -58,13 +58,13 @@
 		}
 
 		// Set the minimum lenth/size for property
-		public function min(?int $value = null) {
+		public function min(?int $value = null): self {
 			$this->min = $value;
 			return $this;
 		}
 
 		// Set the maximum length/size for property
-		public function max(?int $value = null) {
+		public function max(?int $value = null): self {
 			$this->max = $value;
 			return $this;
 		}

--- a/src/Rules.php
+++ b/src/Rules.php
@@ -2,14 +2,10 @@
 
 	namespace ReflectRules;
 
-	use \victorwesterlund\xEnum;
-
 	use \ReflectRules\Scope;
 
 	// Supported types for is_type()
 	enum Type {
-		use xEnum;
-		
 		case NULL;
 		case ENUM;
 		case ARRAY;

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -55,6 +55,7 @@
 				}
 
 				$this->add_error(Error::MISSING_REQUIRED_PROPERTY, $scope, $name, $name);
+				return;
 			}
 
 			// Get value from scope for the current property


### PR DESCRIPTION
This PR changes a lot of things how rules are validated and returned in rulesets.

Rulesets now do what their names says and evaluates a **set** of **`Rules`**. Evaluation is no longer limited to a single `GET()` or `POST()` scope.

This plugin no longer returns a `Reflect\Response`, but insead exposes all errors found with two new methods `Ruleset->is_valid()` and `Ruleset->get_errors()`.

See the README in this PR for full documentation of all changes.